### PR TITLE
Use ticks in documentation (not nanos)

### DIFF
--- a/src/HdrHistogram/HistogramBase.cs
+++ b/src/HdrHistogram/HistogramBase.cs
@@ -113,7 +113,7 @@ namespace HdrHistogram
 
 
         /// <summary>
-        /// Construct a histogram given the Lowest and Highest values to be tracked and a number of significant decimal digits.
+        /// Construct a histogram given the lowest and highest values to be tracked and a number of significant decimal digits.
         /// </summary>
         /// <param name="lowestTrackableValue">The lowest value that can be tracked (distinguished from 0) by the histogram.
         /// Must be a positive integer that is &gt;= 1.
@@ -122,13 +122,15 @@ namespace HdrHistogram
         /// <param name="highestTrackableValue">The highest value to be tracked by the histogram.
         /// Must be a positive integer that is &gt;= (2 * lowestTrackableValue).
         /// </param>
-        /// <param name="numberOfSignificantValueDigits">The number of significant decimal digits to which the histogram will maintain value resolution and separation. 
+        /// <param name="numberOfSignificantValueDigits">
+        /// The number of significant decimal digits to which the histogram will maintain value resolution and separation. 
         /// Must be a non-negative integer between 0 and 5.
         /// </param>
         /// <remarks>
         /// Providing a lowestTrackableValue is useful in situations where the units used for the histogram's values are much 
-        /// smaller that the minimal accuracy required. E.g. when tracking time values stated in ticks (100 nanoseconds), where
-        /// the minimal accuracy required is a microsecond, the proper value for lowestTrackableValue would be 10.
+        /// smaller that the minimal accuracy required.
+        /// For example when tracking time values stated in ticks (100 nanoseconds), where the minimal accuracy required is a
+        /// microsecond, the proper value for lowestTrackableValue would be 10.
         /// </remarks>
         protected HistogramBase(long lowestTrackableValue, long highestTrackableValue, int numberOfSignificantValueDigits)
         {

--- a/src/HdrHistogram/IntHistogram.cs
+++ b/src/HdrHistogram/IntHistogram.cs
@@ -47,7 +47,7 @@ namespace HdrHistogram
         private long _totalCount;
 
         /// <summary>
-        /// Construct a IntHistogram given the Highest value to be tracked and a number of significant decimal digits. 
+        /// Construct an <see cref="IntHistogram"/> given the highest value to be tracked and a number of significant decimal digits. 
         /// The histogram will be constructed to implicitly track(distinguish from 0) values as low as 1. 
         /// </summary>
         /// <param name="highestTrackableValue">The highest value to be tracked by the histogram. Must be a positive integer that is &gt;= 2.</param>
@@ -56,15 +56,18 @@ namespace HdrHistogram
             : this(1, highestTrackableValue, numberOfSignificantValueDigits)
         {
         }
-        
+
         /// <summary>
-        /// Construct a IntHistogram given the Lowest and Highest values to be tracked and a number of significant decimal digits.
-        /// Providing a lowestTrackableValue is useful is situations where the units used for the histogram's values are much smaller that the minimal accuracy required.
-        /// E.g. when tracking time values stated in nanosecond units, where the minimal accuracy required is a microsecond, the proper value for lowestTrackableValue would be 1000.
+        /// Construct a <see cref="IntHistogram"/> given the lowest and highest values to be tracked and a number of significant decimal digits.
+        /// Providing a <paramref name="lowestTrackableValue"/> is useful is situations where the units used for the histogram's values are much smaller that the minimal accuracy required.
+        /// For example when tracking time values stated in ticks (100 nanosecond units), where the minimal accuracy required is a microsecond, the proper value for <paramref name="lowestTrackableValue"/> would be 10.
         /// </summary>
-        /// <param name="lowestTrackableValue">The lowest value that can be tracked (distinguished from 0) by the histogram.
-        /// Must be a positive integer that is &gt;= 1. May be internally rounded down to nearest power of 2.</param>
-        /// <param name="highestTrackableValue">The highest value to be tracked by the histogram. Must be a positive integer that is &gt;= (2 * lowestTrackableValue).</param>
+        /// <param name="lowestTrackableValue">
+        /// The lowest value that can be tracked (distinguished from 0) by the histogram.
+        /// Must be a positive integer that is &gt;= 1. 
+        /// May be internally rounded down to nearest power of 2.
+        /// </param>
+        /// <param name="highestTrackableValue">The highest value to be tracked by the histogram. Must be a positive integer that is &gt;= (2 * <paramref name="lowestTrackableValue"/>).</param>
         /// <param name="numberOfSignificantValueDigits">The number of significant decimal digits to which the histogram will maintain value resolution and separation.Must be a non-negative integer between 0 and 5.</param>
         public IntHistogram(long lowestTrackableValue, long highestTrackableValue, int numberOfSignificantValueDigits)
             : base(lowestTrackableValue, highestTrackableValue, numberOfSignificantValueDigits)

--- a/src/HdrHistogram/LongHistogram.cs
+++ b/src/HdrHistogram/LongHistogram.cs
@@ -47,7 +47,7 @@ namespace HdrHistogram
         private long _totalCount;
 
         /// <summary>
-        /// Construct a Histogram given the Highest value to be tracked and a number of significant decimal digits. 
+        /// Construct a Histogram given the highest value to be tracked and a number of significant decimal digits. 
         /// The histogram will be constructed to implicitly track(distinguish from 0) values as low as 1.
         /// </summary>
         /// <param name="highestTrackableValue">The highest value to be tracked by the histogram. Must be a positive integer that is &gt;= 2.</param>

--- a/src/HdrHistogram/LongHistogram.cs
+++ b/src/HdrHistogram/LongHistogram.cs
@@ -60,13 +60,16 @@ namespace HdrHistogram
         }
 
         /// <summary>
-        /// Construct a Histogram given the Lowest and Highest values to be tracked and a number of significant decimal digits.
-        /// Providing a lowestTrackableValue is useful is situations where the units used for the histogram's values are much smaller that the minimal accuracy required. 
-        /// E.g. when tracking time values stated in nanosecond units, where the minimal accuracy required is a microsecond, the proper value for lowestTrackableValue would be 1000.
+        /// Construct a <see cref="LongHistogram"/> given the lowest and highest values to be tracked and a number of significant decimal digits.
+        /// Providing a <paramref name="lowestTrackableValue"/> is useful is situations where the units used for the histogram's values are much smaller that the minimal accuracy required. 
+        /// For example when tracking time values stated in tick (100 nanosecond units), where the minimal accuracy required is a microsecond, the proper value for <paramref name="lowestTrackableValue"/> would be 10.
         /// </summary>
-        /// <param name="lowestTrackableValue">The lowest value that can be tracked (distinguished from 0) by the histogram.
-        /// Must be a positive integer that is &gt;= 1. May be internally rounded down to nearest power of 2.</param>
-        /// <param name="highestTrackableValue">The highest value to be tracked by the histogram. Must be a positive integer that is &gt;= (2 * lowestTrackableValue).</param>
+        /// <param name="lowestTrackableValue">
+        /// The lowest value that can be tracked (distinguished from 0) by the histogram.
+        /// Must be a positive integer that is &gt;= 1. 
+        /// May be internally rounded down to nearest power of 2.
+        /// </param>
+        /// <param name="highestTrackableValue">The highest value to be tracked by the histogram. Must be a positive integer that is &gt;= (2 * <paramref name="lowestTrackableValue"/>).</param>
         /// <param name="numberOfSignificantValueDigits">The number of significant decimal digits to which the histogram will maintain value resolution and separation.
         /// Must be a non-negative integer between 0 and 5.
         /// </param>

--- a/src/HdrHistogram/ShortHistogram.cs
+++ b/src/HdrHistogram/ShortHistogram.cs
@@ -47,7 +47,7 @@ namespace HdrHistogram
         private long _totalCount;
 
         /// <summary>
-        /// Construct a ShortHistogram given the Highest value to be tracked and a number of significant decimal digits. 
+        /// Construct a <see cref="ShortHistogram"/> given the Highest value to be tracked and a number of significant decimal digits. 
         /// The histogram will be constructed to implicitly track (distinguish from 0) values as low as 1. 
         /// </summary>
         /// <param name="highestTrackableValue">The highest value to be tracked by the histogram. Must be a positive integer that is &gt;= 2.</param>
@@ -58,15 +58,16 @@ namespace HdrHistogram
         }
 
         /// <summary>
-        /// Construct a ShortHistogram given the Lowest and Highest values to be tracked and a number of significant
-        /// decimal digits.Providing a lowestTrackableValue is useful is situations where the units used
-        /// for the histogram's values are much smaller that the minimal accuracy required. E.g. when tracking
-        /// time values stated in nanosecond units, where the minimal accuracy required is a microsecond, the
-        /// proper value for lowestTrackableValue would be 1000.
+        /// Construct a <see cref="ShortHistogram"/> given the Lowest and Highest values to be tracked and a number of significant decimal digits.
+        /// Providing a <paramref name="lowestTrackableValue"/> is useful is situations where the units used for the histogram's values are much smaller that the minimal accuracy required. 
+        /// For example when tracking time values stated in ticks (100 nanosecond units), where the minimal accuracy required is a microsecond, the proper value for <paramref name="lowestTrackableValue"/> would be 10.
         /// </summary>
-        /// <param name="lowestTrackableValue">The lowest value that can be tracked (distinguished from 0) by the histogram.
-        /// Must be a positive integer that is &gt;= 1. May be internally rounded down to nearest power of 2.</param>
-        /// <param name="highestTrackableValue">The highest value to be tracked by the histogram. Must be a positive integer that is &gt;= (2 * lowestTrackableValue).</param>
+        /// <param name="lowestTrackableValue">
+        /// The lowest value that can be tracked (distinguished from 0) by the histogram.
+        /// Must be a positive integer that is &gt;= 1. 
+        /// May be internally rounded down to nearest power of 2.
+        /// </param>
+        /// <param name="highestTrackableValue">The highest value to be tracked by the histogram. Must be a positive integer that is &gt;= (2 * <paramref name="lowestTrackableValue"/>).</param>
         /// <param name="numberOfSignificantValueDigits">The number of significant decimal digits to which the histogram will maintain value resolution and separation.
         /// Must be a non-negative integer between 0 and 5.</param>
         public ShortHistogram(long lowestTrackableValue, long highestTrackableValue, int numberOfSignificantValueDigits)

--- a/src/HdrHistogram/ShortHistogram.cs
+++ b/src/HdrHistogram/ShortHistogram.cs
@@ -47,7 +47,7 @@ namespace HdrHistogram
         private long _totalCount;
 
         /// <summary>
-        /// Construct a <see cref="ShortHistogram"/> given the Highest value to be tracked and a number of significant decimal digits. 
+        /// Construct a <see cref="ShortHistogram"/> given the highest value to be tracked and a number of significant decimal digits. 
         /// The histogram will be constructed to implicitly track (distinguish from 0) values as low as 1. 
         /// </summary>
         /// <param name="highestTrackableValue">The highest value to be tracked by the histogram. Must be a positive integer that is &gt;= 2.</param>
@@ -58,7 +58,7 @@ namespace HdrHistogram
         }
 
         /// <summary>
-        /// Construct a <see cref="ShortHistogram"/> given the Lowest and Highest values to be tracked and a number of significant decimal digits.
+        /// Construct a <see cref="ShortHistogram"/> given the lowest and highest values to be tracked and a number of significant decimal digits.
         /// Providing a <paramref name="lowestTrackableValue"/> is useful is situations where the units used for the histogram's values are much smaller that the minimal accuracy required. 
         /// For example when tracking time values stated in ticks (100 nanosecond units), where the minimal accuracy required is a microsecond, the proper value for <paramref name="lowestTrackableValue"/> would be 10.
         /// </summary>

--- a/src/HdrHistogram/SynchronizedHistogram.cs
+++ b/src/HdrHistogram/SynchronizedHistogram.cs
@@ -34,7 +34,7 @@ namespace HdrHistogram
 
 
         /// <summary>
-        /// Construct a SynchronizedHistogram given the Highest value to be tracked and a number of significant decimal digits. 
+        /// Construct a <see cref="SynchronizedHistogram"/> given the Highest value to be tracked and a number of significant decimal digits. 
         /// The histogram will be constructed to implicitly track(distinguish from 0) values as low as 1.
         /// </summary>
         /// <param name="highestTrackableValue">The highest value to be tracked by the histogram. Must be a positive integer that is &gt;= 2.</param>
@@ -48,14 +48,19 @@ namespace HdrHistogram
         }
 
         /// <summary>
-        /// Construct a SynchronizedHistogram given the Lowest and Highest values to be tracked and a number of significant decimal digits.
-        /// Providing a lowestTrackableValue is useful is situations where the units used for the histogram's values are much smaller that the minimal accuracy required. 
-        /// E.g. when tracking time values stated in ticks (100 nanoseconds), where the minimal accuracy required is a microsecond, the proper value for <paramref name="lowestTrackableValue"/> would be 10.
+        /// Construct a <see cref="SynchronizedHistogram"/> given the lowest and highest values to be tracked and a number of significant decimal digits.
+        /// Providing a <paramref name="lowestTrackableValue"/> is useful is situations where the units used for the histogram's values are much smaller that the minimal accuracy required. 
+        /// For example when tracking time values stated in ticks (100 nanoseconds), where the minimal accuracy required is a microsecond, the proper value for <paramref name="lowestTrackableValue"/> would be 10.
         /// </summary>
-        /// <param name="lowestTrackableValue">The lowest value that can be tracked (distinguished from 0) by the histogram.
-        /// Must be a positive integer that is &gt;= 1. May be internally rounded down to nearest power of 2.</param>
-        /// <param name="highestTrackableValue">The highest value to be tracked by the histogram. 
-        /// Must be a positive integer that is &gt;= (2 * lowestTrackableValue).</param>
+        /// <param name="lowestTrackableValue">
+        /// The lowest value that can be tracked (distinguished from 0) by the histogram.
+        /// Must be a positive integer that is &gt;= 1.
+        /// May be internally rounded down to nearest power of 2.
+        /// </param>
+        /// <param name="highestTrackableValue">
+        /// The highest value to be tracked by the histogram. 
+        /// Must be a positive integer that is &gt;= (2 * <paramref name="lowestTrackableValue"/>).
+        /// </param>
         /// <param name="numberOfSignificantValueDigits">The number of significant decimal digits to which the histogram will maintain value resolution and separation. 
         /// Must be a non-negative integer between 0 and 5.
         /// </param>

--- a/src/HdrHistogram/SynchronizedHistogram.cs
+++ b/src/HdrHistogram/SynchronizedHistogram.cs
@@ -34,7 +34,7 @@ namespace HdrHistogram
 
 
         /// <summary>
-        /// Construct a <see cref="SynchronizedHistogram"/> given the Highest value to be tracked and a number of significant decimal digits. 
+        /// Construct a <see cref="SynchronizedHistogram"/> given the highest value to be tracked and a number of significant decimal digits. 
         /// The histogram will be constructed to implicitly track(distinguish from 0) values as low as 1.
         /// </summary>
         /// <param name="highestTrackableValue">The highest value to be tracked by the histogram. Must be a positive integer that is &gt;= 2.</param>


### PR DESCRIPTION
As .NET does not currently support a higher resolution that 1 tick (100 nanoseconds) for any timing, the new api defaults to this as the resolution. This PR adjusts the documentation to match that default.

Closes #13 
