### PR TITLE
Custom GetConstructor method for cross platform support

### DIFF
--- a/src/HdrHistogram/HdrHistogram.csproj
+++ b/src/HdrHistogram/HdrHistogram.csproj
@@ -48,6 +48,7 @@
     <Compile Include="HistogramExtensions.cs" />
     <Compile Include="OutputScalingFactor.cs" />
     <Compile Include="Properties\AssemblyInfo.g.cs" />
+    <Compile Include="Utilities\ArrayExtensions.cs" />
     <Compile Include="Utilities\CountingMemoryStream.cs" />
     <Compile Include="IntHistogram.cs" />
     <Compile Include="Iteration\AbstractHistogramEnumerator.cs" />
@@ -62,6 +63,7 @@
     <Compile Include="Iteration\PercentileEnumerator.cs" />
     <Compile Include="Iteration\RecordedValuesEnumerator.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Utilities\TypeHelper.cs" />
     <Compile Include="Utilities\WrappedBuffer.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/HdrHistogram/HistogramBase.cs
+++ b/src/HdrHistogram/HistogramBase.cs
@@ -528,9 +528,8 @@ namespace HdrHistogram
         /// Encode this histogram in compressed form into a byte array
         /// </summary>
         /// <param name="targetBuffer">The buffer to encode into</param>
-        /// <param name="compressionLevel">Compression level.</param>
         /// <returns>The number of bytes written to the buffer</returns>
-        public long EncodeIntoCompressedByteBuffer(ByteBuffer targetBuffer, CompressionLevel compressionLevel = CompressionLevel.Optimal)
+        public long EncodeIntoCompressedByteBuffer(ByteBuffer targetBuffer)
         {
             var temp = ByteBuffer.Allocate(GetNeededByteBufferCapacity(CountsArrayLength));
             lock (UpdateLock)
@@ -544,7 +543,8 @@ namespace HdrHistogram
                 int compressedDataLength;
                 using (var outputStream = targetBuffer.GetWriter())
                 {
-                    using (var compressor = new DeflateStream(outputStream, compressionLevel))
+                    //using (var compressor = new DeflateStream(outputStream, compressionLevel))    //Make usable by Mono -LC
+                    using (var compressor = new DeflateStream(outputStream, CompressionMode.Compress))
                     {
                         temp.WriteTo(compressor, 0, uncompressedLength);
                     }
@@ -936,7 +936,7 @@ namespace HdrHistogram
 
             try
             {
-                var constructor = histogramClass.GetConstructor(HistogramClassConstructorArgsTypes);
+                var constructor =  TypeHelper.GetConstructor(histogramClass, HistogramClassConstructorArgsTypes);
                 if (constructor == null)
                     throw new ArgumentException("The target type does not have a supported constructor", nameof(histogramClass));
                 var histogram = (HistogramBase)constructor.Invoke(new object[] { lowestTrackableValue, highestTrackableValue, numberOfSignificantValueDigits });

--- a/src/HdrHistogram/Utilities/ArrayExtensions.cs
+++ b/src/HdrHistogram/Utilities/ArrayExtensions.cs
@@ -1,0 +1,30 @@
+﻿namespace HdrHistogram.Utilities
+{
+    /// <summary>
+    /// Extension methods for Arrays.
+    /// </summary>
+    public static class ArrayExtensions
+    {
+        /// <summary>
+        /// Checks if the two arrays have the same items in the same order.
+        /// </summary>
+        /// <typeparam name="T">The type of the items in the arrays.</typeparam>
+        /// <param name="source">The source array to check.</param>
+        /// <param name="other">The other array to check against.</param>
+        /// <returns>Returns <c>true</c> if the arrays are of the same length and each item by index is equal, else <c>false</c>.</returns>
+        public static bool IsSequenceEqual<T>(this T[] source, T[] other)
+        {
+            if (source.Length != other.Length)
+                return false;
+
+            for (int i = 0; i < other.Length; i++)
+            {
+                if (!Equals(source[i], other[i]))
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
+    }
+}

--- a/src/HdrHistogram/Utilities/TypeHelper.cs
+++ b/src/HdrHistogram/Utilities/TypeHelper.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Linq;
+using System.Reflection;
+
+namespace HdrHistogram.Utilities
+{
+    internal static class TypeHelper
+    {
+        /// <summary>
+        /// Gets the constructor that matches the parameter array.
+        /// Searches for a public instance constructor whose parameters match the types in the specified array.
+        /// </summary>
+        /// <param name="type">The type to search.</param>
+        /// <param name="ctorArgTypes">An array of <see cref="Type"/> objects representing the number, order and type of the parameters for the desired constructor.</param>
+        /// <returns>The <see cref="ConstructorInfo"/> if a match is found, else <c>null</c>.</returns>
+        /// <remarks>
+        /// In most versions of .NET this method is provided directly on <see cref="Type"/>, however for full support, we provide this ourselves.
+        /// </remarks>
+        public static ConstructorInfo GetConstructor( Type type, Type[] ctorArgTypes)
+        {
+            var info = type.GetTypeInfo();
+            return info.DeclaredConstructors
+                .FirstOrDefault(ctor => IsParameterMatch(ctor, ctorArgTypes));
+        }
+
+        private static bool IsParameterMatch(ConstructorInfo ctor, Type[] expectedParamters)
+        {
+            var ctorParams = ctor.GetParameters();
+            return ctorParams.Select(p => p.ParameterType)
+                .ToArray()
+                .IsSequenceEqual(expectedParamters);
+        }
+    }
+}


### PR DESCRIPTION
Helps with #31.This means we are compatible with the following frameworks (according to the .NET Portability Analyzer)
- [ ] .NET v4.0 - Not a priority. Any OS post WinXP can run a runtime higher than 4.0 
- [x] .NET Framework v4.5, v4.5.1, v4.5.2, v4.6, v4.6.1
- [x] .NET Core v5.0, .NET Core Cross Platform v5.0
- [x] .NET Native v1.0
- [x] ASP.NET 5 v1.0
- [x] Mono v3.3
- [x] Windows 8.1
- [x] Windows Phone v8.1
