### PR TITLE
PerfTesting and documenting Record(Action) ext method

### DIFF
--- a/src/HdrHistogram.PerfTests/HdrHistogram.PerfTests.csproj
+++ b/src/HdrHistogram.PerfTests/HdrHistogram.PerfTests.csproj
@@ -57,6 +57,12 @@
     <Compile Include="Throughput\ShortHistogramThoughputTest.cs" />
     <Compile Include="Throughput\SynchronizedHistogramThoughputTest.cs" />
     <Compile Include="Throughput\ThroughputTestResult.cs" />
+    <Compile Include="TimerThroughput\HistogramActionStopwatchCachedIncrementerDelegateThoughputTest.cs" />
+    <Compile Include="TimerThroughput\HistogramActionStopwatchIncrementerThoughputTest.cs" />
+    <Compile Include="TimerThroughput\HistogramActionStopwatchMd5ThoughputTest.cs" />
+    <Compile Include="TimerThroughput\HistogramManualStopwatchIncrementerThoughputTest.cs" />
+    <Compile Include="TimerThroughput\HistogramManualStopwatchMd5ThoughputTest.cs" />
+    <Compile Include="TimerThroughput\HistogramTimerThoughputTestBase.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />

--- a/src/HdrHistogram.PerfTests/Program.cs
+++ b/src/HdrHistogram.PerfTests/Program.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using HdrHistogram.PerfTests.Throughput;
+using HdrHistogram.PerfTests.TimerThroughput;
 
 namespace HdrHistogram.PerfTests
 {
@@ -11,14 +12,15 @@ namespace HdrHistogram.PerfTests
     {
         private static readonly int[] RunSizes =
         {
-            //10000000,
-            //100000000,
+          //10000000,
+          //100000000,
             1000000000,
         };
 
         public static void Main()
         {
             var testTypes = GetHistorgramThroughputTests();
+            //var testTypes = GetHistorgramTimerThroughputTests();
 
             var testResultRunner = from testType in testTypes
                                    from messageCount in RunSizes
@@ -46,6 +48,17 @@ namespace HdrHistogram.PerfTests
                             where !type.IsAbstract
                             where type.IsSubclassOf(typeof(Throughput.HistogramThoughputTestBase))
                             select (HistogramThoughputTestBase)Activator.CreateInstance(type, true);
+
+            return testTypes.ToArray();
+        }
+
+        private static IEnumerable<HistogramTimerThoughputTestBase> GetHistorgramTimerThroughputTests()
+        {
+            var testTypes = from module in typeof(Program).Assembly.GetModules()
+                            from type in module.GetTypes()
+                            where !type.IsAbstract
+                            where type.IsSubclassOf(typeof(HistogramTimerThoughputTestBase))
+                            select (HistogramTimerThoughputTestBase)Activator.CreateInstance(type, true);
 
             return testTypes.ToArray();
         }

--- a/src/HdrHistogram.PerfTests/TimerThroughput/HistogramActionStopwatchCachedIncrementerDelegateThoughputTest.cs
+++ b/src/HdrHistogram.PerfTests/TimerThroughput/HistogramActionStopwatchCachedIncrementerDelegateThoughputTest.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using NUnit.Framework;
+
+namespace HdrHistogram.PerfTests.TimerThroughput
+{
+    [TestFixture]
+    public sealed class HistogramActionStopwatchCachedIncrementerDelegateThoughputTest : HistogramTimerThoughputTestBase
+    {
+        protected override string Label => "LongHistogramAutoStopwatchCachedIncrementer";
+
+        protected override HistogramBase CreateHistogram()
+        {
+            return new LongHistogram(HighestTrackableValue, NumberOfSignificantValueDigits);
+        }
+
+        protected override void RecordLoop(HistogramBase histogram, long loopCount)
+        {
+            Action incrementNumber = IncrementNumber;
+            for (long i = 0; i<loopCount; i++)
+            {
+                histogram.Record(incrementNumber);
+            }
+        }
+    }
+}

--- a/src/HdrHistogram.PerfTests/TimerThroughput/HistogramActionStopwatchIncrementerThoughputTest.cs
+++ b/src/HdrHistogram.PerfTests/TimerThroughput/HistogramActionStopwatchIncrementerThoughputTest.cs
@@ -1,0 +1,23 @@
+using NUnit.Framework;
+
+namespace HdrHistogram.PerfTests.TimerThroughput
+{
+    [TestFixture]
+    public sealed class HistogramActionStopwatchIncrementerThoughputTest : HistogramTimerThoughputTestBase
+    {
+        protected override string Label => "LongHistogramAutoStopwatchIncrementer";
+
+        protected override HistogramBase CreateHistogram()
+        {
+            return new LongHistogram(HighestTrackableValue, NumberOfSignificantValueDigits);
+        }
+
+        protected override void RecordLoop(HistogramBase histogram, long loopCount)
+        {
+            for (long i = 0; i<loopCount; i++)
+            {
+                histogram.Record(IncrementNumber);
+            }
+        }
+    }
+}

--- a/src/HdrHistogram.PerfTests/TimerThroughput/HistogramActionStopwatchMd5ThoughputTest.cs
+++ b/src/HdrHistogram.PerfTests/TimerThroughput/HistogramActionStopwatchMd5ThoughputTest.cs
@@ -1,0 +1,23 @@
+using NUnit.Framework;
+
+namespace HdrHistogram.PerfTests.TimerThroughput
+{
+    [TestFixture]
+    public sealed class HistogramActionStopwatchMd5ThoughputTest : HistogramTimerThoughputTestBase
+    {
+        protected override string Label => "LongHistogramAutoStopwatchMd5";
+
+        protected override HistogramBase CreateHistogram()
+        {
+            return new LongHistogram(HighestTrackableValue, NumberOfSignificantValueDigits);
+        }
+
+        protected override void RecordLoop(HistogramBase histogram, long loopCount)
+        {
+            for (long i = 0; i<loopCount; i++)
+            {
+                histogram.Record(() => base.Md5HashIncrementingNumber());
+            }
+        }
+    }
+}

--- a/src/HdrHistogram.PerfTests/TimerThroughput/HistogramManualStopwatchIncrementerThoughputTest.cs
+++ b/src/HdrHistogram.PerfTests/TimerThroughput/HistogramManualStopwatchIncrementerThoughputTest.cs
@@ -1,0 +1,27 @@
+using System.Diagnostics;
+using NUnit.Framework;
+
+namespace HdrHistogram.PerfTests.TimerThroughput
+{
+    [TestFixture]
+    public sealed class HistogramManualStopwatchIncrementerThoughputTest : HistogramTimerThoughputTestBase
+    {
+        protected override string Label => "LongHistogramManualStopwatchIncrementer";
+
+        protected override HistogramBase CreateHistogram()
+        {
+            return new LongHistogram(HighestTrackableValue, NumberOfSignificantValueDigits);
+        }
+
+        protected override void RecordLoop(HistogramBase histogram, long loopCount)
+        {
+            for (long i = 0; i<loopCount; i++)
+            {
+                long startTimestamp = Stopwatch.GetTimestamp();
+                base.IncrementNumber();
+                long ticks = Stopwatch.GetTimestamp() - startTimestamp;
+                histogram.RecordValue(ticks);
+            }
+        }
+    }
+}

--- a/src/HdrHistogram.PerfTests/TimerThroughput/HistogramManualStopwatchMd5ThoughputTest.cs
+++ b/src/HdrHistogram.PerfTests/TimerThroughput/HistogramManualStopwatchMd5ThoughputTest.cs
@@ -1,0 +1,27 @@
+using System.Diagnostics;
+using NUnit.Framework;
+
+namespace HdrHistogram.PerfTests.TimerThroughput
+{
+    [TestFixture]
+    public sealed class HistogramManualStopwatchMd5ThoughputTest : HistogramTimerThoughputTestBase
+    {
+        protected override string Label => "LongHistogramManualStopwatchMd5";
+
+        protected override HistogramBase CreateHistogram()
+        {
+            return new LongHistogram(HighestTrackableValue, NumberOfSignificantValueDigits);
+        }
+
+        protected override void RecordLoop(HistogramBase histogram, long loopCount)
+        {
+            for (long i = 0; i<loopCount; i++)
+            {
+                long startTimestamp = Stopwatch.GetTimestamp();
+                var result = base.Md5HashIncrementingNumber();
+                long ticks = Stopwatch.GetTimestamp() - startTimestamp;
+                histogram.RecordValue(ticks);
+            }
+        }
+    }
+}

--- a/src/HdrHistogram/HdrHistogram.csproj
+++ b/src/HdrHistogram/HdrHistogram.csproj
@@ -95,9 +95,6 @@
     <Compile Include="Utilities\WrappedBuffer.cs" />
     <Compile Include="ZigZagEncoding.cs" />
   </ItemGroup>
-  <ItemGroup>
-    <None Include="HdrHistogram.nuspec" />
-  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/HdrHistogram/HistogramExtensions.cs
+++ b/src/HdrHistogram/HistogramExtensions.cs
@@ -242,16 +242,47 @@ namespace HdrHistogram
         }
 
         /// <summary>
-        /// Executes the action and records the time to complete the action. The time is recorded in ticks.
+        /// Executes the action and records the time to complete the action. 
+        /// The time is recorded in ticks. 
+        /// Note this is a convenience method and can carry a cost.
+        /// If the <paramref name="action"/> delegate is not cached, then it may incur an allocation cost for each invocation of <see cref="Record"/>
         /// </summary>
         /// <param name="histogram">The Histogram to record the latency in.</param>
         /// <param name="action">The functionality to execute and measure</param>
         /// <remarks>
+        /// <para>
         /// Ticks are used as the unit of recording here as they are the smallest unit that .NET can measure
         /// and require no conversion at time of recording. Instead conversion (scaling) can be done at time
         /// of output to microseconds, milliseconds, seconds or other appropriate unit.
+        /// </para>
+        /// <para>
+        /// If you are able to cache the <paramref name="action"/> delegate, then doing so is encouraged.
+        /// <example>
+        /// Here are two examples.
+        /// The first does not cache the delegate
+        /// 
+        /// <code>
+        /// for (long i = 0; i &lt; loopCount; i++)
+        /// {
+        ///   histogram.Record(IncrementNumber);
+        /// }
+        /// </code>
+        /// This second example does cache the delegate
+        /// <code>
+        /// Action incrementNumber = IncrementNumber;
+        /// for (long i = 0; i &lt; loopCount; i++)
+        /// {
+        ///   histogram.Record(incrementNumber);
+        /// }
+        /// </code>
+        /// In the second example, we will not be making allocations each time i.e. an allocation of an <seealso cref="Action"/> from <code>IncrementNumber</code>.
+        /// This will reduce memory pressure and therefore garbage collection penalties.
+        /// For performance sensitive applications, this method may not be suitable.
+        /// As always, you are encouraged to test and measure the impact for your scenario.
+        /// </example>
+        /// </para>
         /// </remarks>
-        public static void RecordLatency(this HistogramBase histogram, Action action)
+        public static void Record(this HistogramBase histogram, Action action)
         {
             var start = Stopwatch.GetTimestamp();
             action();


### PR DESCRIPTION
For convenience, there is a `Record(Action)` extension method (formerly `RecordAction(Action)`).
This PR makes the rename, documents it better and creates some performance tests to validate its usage.
